### PR TITLE
Feature/dwr 737 groups view api

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/model/Group.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/model/Group.java
@@ -1,0 +1,78 @@
+package org.opentestsystem.rdw.admin.model;
+
+public class Group {
+    private String name;
+    private String schoolName;
+    private String subject;
+    private int schoolYear;
+
+    /**
+     * @return The name of the group
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return The name of the school
+     */
+    public String getSchoolName() {
+        return schoolName;
+    }
+
+    /**
+     * @return The subject this group applies to, or NULL if it applies to all subjects
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * @return The school year for this group
+     */
+    public int getSchoolYear() {
+        return schoolYear;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String name;
+        private String schoolName;
+        private String subject;
+        private int schoolYear;
+
+        public Builder name(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder schoolName(final String schoolName) {
+            this.schoolName = schoolName;
+            return this;
+        }
+
+        public Builder subject(final String subject) {
+            this.subject = subject;
+            return this;
+        }
+
+        public Builder schoolYear(final int schoolYear) {
+            this.schoolYear = schoolYear;
+            return this;
+        }
+
+        public Group build() {
+            Group group = new Group();
+
+            group.name = name;
+            group.schoolName = schoolName;
+            group.subject = subject;
+            group.schoolYear = schoolYear;
+
+            return group;
+        }
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupQuery.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupQuery.java
@@ -1,0 +1,65 @@
+package org.opentestsystem.rdw.admin.model;
+
+import java.util.Set;
+
+public class GroupQuery {
+    private int schoolId;
+    private Set<Integer> subjectIds;
+    private int schoolYear;
+
+    /**
+     * @return The school id to query the group by
+     */
+    public int getSchoolId() {
+        return schoolId;
+    }
+
+    /**
+     * @return The subject ids to query the group by
+     */
+    public Set<Integer> getSubjectIds() {
+        return subjectIds;
+    }
+
+    /**
+     * @return The school year to query the group by
+     */
+    public int getSchoolYear() {
+        return schoolYear;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int schoolId;
+        private Set<Integer> subjectIds;
+        private int schoolYear;
+
+        public Builder schoolId(final int schoolId) {
+            this.schoolId = schoolId;
+            return this;
+        }
+
+        public Builder subjectIds(final Set<Integer> subjectIds) {
+            this.subjectIds = subjectIds;
+            return this;
+        }
+
+        public Builder schoolYear(final int schoolyear) {
+            this.schoolYear = schoolyear;
+            return this;
+        }
+
+        public GroupQuery build() {
+            GroupQuery query = new GroupQuery();
+
+            query.schoolId = schoolId;
+            query.subjectIds = subjectIds;
+            query.schoolYear = schoolYear;
+
+            return query;
+        }
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupRepository.java
@@ -1,0 +1,18 @@
+package org.opentestsystem.rdw.admin.repository;
+
+import org.opentestsystem.rdw.admin.common.security.PermissionScope;
+import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+public interface GroupRepository {
+
+    /**
+     * @param permissionScope The user's permission scope
+     * @param query           The query to find groups by
+     * @return all groups matching the provided query
+     */
+    List<Group> findAllByQuery(@NotNull PermissionScope permissionScope, @NotNull GroupQuery query);
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
@@ -1,0 +1,55 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import com.google.common.collect.ImmutableMap;
+import org.opentestsystem.rdw.admin.common.security.PermissionScope;
+import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.repository.GroupRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+import static org.opentestsystem.rdw.admin.common.jdbc.QueryUtils.getSecurityParameters;
+
+@Repository
+public class JdbcGroupRepository implements GroupRepository {
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.group.findAllByQuery}")
+    private String findAllQuery;
+
+    @Autowired
+    JdbcGroupRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public List<Group> findAllByQuery(@NotNull final PermissionScope permissionScope, @NotNull final GroupQuery query) {
+        return template.query(
+                findAllQuery,
+                new MapSqlParameterSource()
+                        .addValues(getSecurityParameters(permissionScope))
+                        .addValues(getQueryParameters(query)),
+                (row, index) -> Group.builder()
+                        .name(row.getString("group_name"))
+                        .schoolName(row.getString("school_name"))
+                        .schoolYear(row.getInt("school_year"))
+                        .subject(row.getString("subject_code"))
+                        .build()
+        );
+    }
+
+    private static Map<String, Object> getQueryParameters(final GroupQuery query) {
+        return ImmutableMap.<String, Object>builder()
+                .put("school_id", query.getSchoolId())
+                .put("subject_ids", query.getSubjectIds())
+                .put("school_year", query.getSchoolYear())
+                .build();
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/GroupService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/GroupService.java
@@ -1,0 +1,13 @@
+package org.opentestsystem.rdw.admin.service;
+
+import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.security.User;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.util.List;
+
+@PreAuthorize("hasAuthority('PERM_GROUP_READ')")
+public interface GroupService {
+    List<Group> getByQuery(User user, GroupQuery query);
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
@@ -1,0 +1,27 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.repository.GroupRepository;
+import org.opentestsystem.rdw.admin.security.User;
+import org.opentestsystem.rdw.admin.service.GroupService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DefaultGroupService implements GroupService {
+
+    private final GroupRepository repository;
+
+    @Autowired
+    DefaultGroupService(GroupRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<Group> getByQuery(final User user, final GroupQuery query) {
+        return repository.findAllByQuery(user.getPermissionsById().get("GROUP_READ").getScope(), query);
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupController.java
@@ -1,0 +1,29 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.security.User;
+import org.opentestsystem.rdw.admin.service.GroupService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class GroupController {
+
+    private final GroupService service;
+
+    @Autowired
+    GroupController(GroupService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/api/groups")
+    public List<Group> get(@AuthenticationPrincipal final User user, GroupQuery query) {
+        return service.getByQuery(user, query);
+    }
+
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
@@ -31,7 +31,7 @@ public class GroupQueryArgumentResolver implements HandlerMethodArgumentResolver
                 .schoolId(parseInt(webRequest.getParameter("schoolId")))
                 .schoolYear(parseInt(webRequest.getParameter("schoolYear")))
                 .subjectIds(Stream
-                        .of(webRequest.getParameterValues("schoolYear"))
+                        .of(webRequest.getParameterValues("subjectId"))
                         .map(Integer::parseInt)
                         .collect(Collectors.toSet()))
                 .build();

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
@@ -1,0 +1,39 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.Integer.parseInt;
+
+
+/**
+ * An argument resolve for the import query object.
+ */
+public class GroupQueryArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().equals(GroupQuery.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter,
+                                  final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest,
+                                  final WebDataBinderFactory binderFactory) throws Exception {
+        return GroupQuery.builder()
+                .schoolId(parseInt(webRequest.getParameter("schoolId")))
+                .schoolYear(parseInt(webRequest.getParameter("schoolYear")))
+                .subjectIds(Stream
+                        .of(webRequest.getParameterValues("schoolYear"))
+                        .map(Integer::parseInt)
+                        .collect(Collectors.toSet()))
+                .build();
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/WebMvcContext.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/WebMvcContext.java
@@ -1,0 +1,16 @@
+package org.opentestsystem.rdw.admin.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import java.util.List;
+
+@Configuration
+public class WebMvcContext extends WebMvcConfigurerAdapter {
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new GroupQueryArgumentResolver());
+    }
+}

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -9,6 +9,20 @@ sql:
       from district
       where natural_id in (:naturalIds)
 
+  group:
+    findAllByQuery: >-
+      select sg.name as group_name,
+        sc.name as school_name,
+        su.code as subject_code,
+        sg.school_year
+      from student_group sg
+        join school sc on sc.id = sg.school_id
+        left join subject su on su.id = sg.subject_id
+      where sg.school_id = :school_id
+        and (sg.subject_id is null or sg.subject_id in (:subject_ids))
+        and sg.school_year = :school_year
+        and (1=:statewide or sc.district_id in (:district_ids) or sg.school_id in (:school_ids))
+
   school:
     findAllIds: >-
       select natural_id, id

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
@@ -1,0 +1,114 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.repository.RepositoryIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+import static org.opentestsystem.rdw.admin.common.test.support.PermissionScopes.districts;
+import static org.opentestsystem.rdw.admin.common.test.support.PermissionScopes.schools;
+import static org.opentestsystem.rdw.admin.common.test.support.PermissionScopes.statewide;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(SpringRunner.class)
+@RepositoryIT
+@ContextConfiguration(classes = {JdbcGroupRepository.class})
+@Sql(scripts = {"classpath:integration-test-data.sql"})
+@ActiveProfiles("test")
+public class JdbcGroupRepositoryIT {
+
+    @Autowired
+    JdbcGroupRepository repository;
+
+    @Test
+    public void itShouldFindByQuery() {
+        GroupQuery query = GroupQuery.builder()
+                .schoolId(-10)
+                .schoolYear(2017)
+                .subjectIds(ImmutableSet.of(1))
+                .build();
+
+        List<Group> actual = repository.findAllByQuery(statewide(), query);
+
+        assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    public void itShouldFindWhenSubjectIdIsNull() {
+        GroupQuery query = GroupQuery.builder()
+                .schoolId(-10)
+                .schoolYear(2017)
+                .subjectIds(ImmutableSet.of(2))
+                .build();
+
+        List<Group> actual = repository.findAllByQuery(statewide(), query);
+
+        assertThat(actual).hasSize(1);
+    }
+
+    @Test
+    public void itShouldNotFindWhenSchoolNotInDistrictPermissionScope() {
+        GroupQuery query = GroupQuery.builder()
+                .schoolId(-10)
+                .schoolYear(2017)
+                .subjectIds(ImmutableSet.of(1))
+                .build();
+
+        List<Group> actual = repository.findAllByQuery(districts(-20L), query);
+
+        assertThat(actual).hasSize(0);
+    }
+
+    @Test
+    public void itShouldNotFindWhenSchoolNotInSchoolPermissionScope() {
+        GroupQuery query = GroupQuery.builder()
+                .schoolId(-10)
+                .schoolYear(2017)
+                .subjectIds(ImmutableSet.of(1))
+                .build();
+
+        List<Group> actual = repository.findAllByQuery(schools(-20L), query);
+
+        assertThat(actual).hasSize(0);
+    }
+
+    @Test
+    public void itShouldPopulateGroupWhenFound() {
+        GroupQuery query = GroupQuery.builder()
+                .schoolId(-10)
+                .schoolYear(2017)
+                .subjectIds(ImmutableSet.of(1))
+                .build();
+
+        List<Group> actual = repository.findAllByQuery(statewide(), query);
+
+        assertThat(actual).hasSize(2);
+
+        assertThat(actual.get(0))
+                .isEqualToComparingFieldByFieldRecursively(
+                        Group.builder()
+                                .name("group1")
+                                .schoolName("school1")
+                                .subject("Math")
+                                .schoolYear(2017)
+                                .build());
+        assertThat(actual.get(1))
+                .isEqualToComparingFieldByField(
+                        Group.builder()
+                                .name("group2")
+                                .schoolName("school1")
+                                .schoolYear(2017)
+                                .build()
+                );
+    }
+}

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/web/GroupControllerIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/web/GroupControllerIT.java
@@ -1,0 +1,86 @@
+package org.opentestsystem.rdw.admin.web;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.security.User;
+import org.opentestsystem.rdw.admin.service.GroupService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.refEq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(GroupController.class)
+public class GroupControllerIT {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private GroupService service;
+
+    private User user = User.builder()
+            .id("user")
+            .authorities(ImmutableSet.of(new SimpleGrantedAuthority("ROLE_USER")))
+            .build();
+
+    @Test
+    public void itShouldGetSchoolsBySingleSubjectId() throws Exception {
+        when(service.getByQuery(any(User.class), refEq(
+                GroupQuery
+                        .builder()
+                        .schoolId(1)
+                        .schoolYear(2017)
+                        .subjectIds(ImmutableSet.of(1))
+                        .build()))
+        ).thenReturn(ImmutableList.of(
+                Group.builder()
+                        .name("test1")
+                        .schoolName("school1")
+                        .subject("ELA")
+                        .build()));
+
+        mvc.perform(get("/api/groups?schoolId=1&subjectId=1&schoolYear=2017")
+                .with(user(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("test1"))
+                .andExpect(jsonPath("$[0].schoolName").value("school1"))
+                .andExpect(jsonPath("$[0].subject").value("ELA"));
+    }
+
+    @Test
+    public void itShouldGetSchoolsByMultipleSubjectIds() throws Exception {
+        when(service.getByQuery(any(User.class), refEq(
+                GroupQuery
+                        .builder()
+                        .schoolId(1)
+                        .schoolYear(2017)
+                        .subjectIds(ImmutableSet.of(1, 2))
+                        .build()))
+        ).thenReturn(ImmutableList.of(Group.builder()
+                .name("test1")
+                .schoolName("school1")
+                .subject("ELA")
+                .build()));
+
+        mvc.perform(get("/api/groups?schoolId=1&subjectId=1&subjectId=2&schoolYear=2017")
+                .with(user(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("test1"))
+                .andExpect(jsonPath("$[0].schoolName").value("school1"))
+                .andExpect(jsonPath("$[0].subject").value("ELA"));
+    }
+}

--- a/webapp/src/test/resources/integration-test-data.sql
+++ b/webapp/src/test/resources/integration-test-data.sql
@@ -1,13 +1,16 @@
+insert into import (id, status, content, contentType, digest) values
+  (-1, 1, 1, '', '');
+
 insert into district (id, natural_id, name) values
   (-10, 'district1', 'district1'),
   (-20, 'district2', 'district2'),
   (-30, 'district3', 'district3');
 
-insert into school (id, district_id, natural_id, name, import_id) VALUES
-  (-10, -10, 'school1', 'school1', -1),
-  (-20, -10, 'school2', 'school2', -1),
-  (-30, -20, 'school3', 'school3', -1),
-  (-40, -30, 'school4', 'school4', -1);
+insert into school (id, district_id, natural_id, name, import_id, update_import_id) VALUES
+  (-10, -10, 'school1', 'school1', -1, -1),
+  (-20, -10, 'school2', 'school2', -1, -1),
+  (-30, -20, 'school3', 'school3', -1, -1),
+  (-40, -30, 'school4', 'school4', -1, -1);
 
 insert into grade (id, code, name) values
   (-1, 'g1', 'grade1'),
@@ -17,14 +20,15 @@ insert into grade (id, code, name) values
 insert into gender (id, code) values
   (-1, 'g1');
 
-insert into student (id, ssid, last_or_surname, first_name, gender_id, gender_code, birthday, import_id) values
-  (-1, 'student1_ssid', 'student1_lastName', 'student1_firstName', -1, 'g1', '2017-01-01 00:00:00.000000', -1),
-  (-2, 'student2_ssid', 'student2_lastName', 'student2_firstName', -1, 'g1', '2017-01-01 00:00:00.000000', -1);
+insert into student (id, ssid, last_or_surname, first_name, gender_id, birthday, import_id, update_import_id) values
+  (-1, 'student1_ssid', 'student1_lastName', 'student1_firstName', -1, '2017-01-01 00:00:00.000000', -1, -1),
+  (-2, 'student2_ssid', 'student2_lastName', 'student2_firstName', -1, '2017-01-01 00:00:00.000000', -1, -1);
 
 -- groups
 
-insert into student_group (id, name, school_id, school_year, subject_id, import_id) values
-  (-1, 'group1', -10, 2017, 1, -1);
+insert into student_group (id, name, school_id, school_year, subject_id, import_id, update_import_id, active) values
+  (-10, 'group1', -10, 2017, 1, -1, -1, 1),
+  (-20, 'group2', -10, 2017, null, -1, -1, 1);
 
 insert into student_group_membership (student_group_id, student_id) values
-  (-1, -1);
+  (-10, -1);


### PR DESCRIPTION
Added api route for getting groups using a GroupQueryArgumentResolver to resolve query params which downstream maps down to sql query params.

Example routes:
`api/groups?schoolId=1&subjectId=1&schoolYear=2017`
`api/groups?schoolId=1&subjectId=1&subjectId=2&schoolYear=2017`

This is mostly just plumbing, likely will be adding additional data points as needed.