### PR TITLE
Added a getFilterOptions method which returns the schools, years, and…

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/model/Group.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/model/Group.java
@@ -1,9 +1,11 @@
 package org.opentestsystem.rdw.admin.model;
 
+import org.opentestsystem.rdw.common.model.Subject;
+
 public class Group {
     private String name;
     private String schoolName;
-    private String subject;
+    private Subject subject;
     private int schoolYear;
 
     /**
@@ -23,7 +25,7 @@ public class Group {
     /**
      * @return The subject this group applies to, or NULL if it applies to all subjects
      */
-    public String getSubject() {
+    public Subject getSubject() {
         return subject;
     }
 
@@ -41,7 +43,7 @@ public class Group {
     public static class Builder {
         private String name;
         private String schoolName;
-        private String subject;
+        private Subject subject;
         private int schoolYear;
 
         public Builder name(final String name) {
@@ -54,7 +56,7 @@ public class Group {
             return this;
         }
 
-        public Builder subject(final String subject) {
+        public Builder subject(final Subject subject) {
             this.subject = subject;
             return this;
         }
@@ -65,7 +67,7 @@ public class Group {
         }
 
         public Group build() {
-            Group group = new Group();
+            final Group group = new Group();
 
             group.name = name;
             group.schoolName = schoolName;

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupFilterOptions.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupFilterOptions.java
@@ -1,0 +1,60 @@
+package org.opentestsystem.rdw.admin.model;
+
+import com.google.common.collect.ImmutableSet;
+import org.opentestsystem.rdw.admin.common.model.Organization;
+import org.opentestsystem.rdw.common.model.Subject;
+
+import java.util.Set;
+
+public class GroupFilterOptions {
+    Set<Organization> schools;
+    Set<Integer> schoolYears;
+    Set<Subject> subjects;
+
+    public Set<Organization> getSchools() {
+        return schools;
+    }
+
+    public Set<Integer> getSchoolYears() {
+        return schoolYears;
+    }
+
+    public Set<Subject> getSubjects() {
+        return subjects;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        Set<Organization> schools;
+        Set<Integer> schoolYears;
+        Set<Subject> subjects;
+
+        public Builder schools(final Set<Organization> schools) {
+            this.schools = ImmutableSet.copyOf(schools);
+            return this;
+        }
+
+        public Builder schoolYears(final Set<Integer> schoolYears) {
+            this.schoolYears = ImmutableSet.copyOf(schoolYears);
+            return this;
+        }
+
+        public Builder subjects(final Set<Subject> subjects) {
+            this.subjects = ImmutableSet.copyOf(subjects);
+            return this;
+        }
+
+        public GroupFilterOptions build() {
+            final GroupFilterOptions filterOptions = new GroupFilterOptions();
+
+            filterOptions.schools = schools;
+            filterOptions.schoolYears = schoolYears;
+            filterOptions.subjects = subjects;
+
+            return filterOptions;
+        }
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupQuery.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupQuery.java
@@ -45,8 +45,8 @@ public class GroupQuery {
             return this;
         }
 
-        public Builder subjectIds(final Set<Subject> subjectIds) {
-            this.subjects = ImmutableSet.copyOf(subjectIds);
+        public Builder subjects(final Set<Subject> subjects) {
+            this.subjects = ImmutableSet.copyOf(subjects);
             return this;
         }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupQuery.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/model/GroupQuery.java
@@ -1,10 +1,13 @@
 package org.opentestsystem.rdw.admin.model;
 
+import com.google.common.collect.ImmutableSet;
+import org.opentestsystem.rdw.common.model.Subject;
+
 import java.util.Set;
 
 public class GroupQuery {
     private int schoolId;
-    private Set<Integer> subjectIds;
+    private Set<Subject> subjects;
     private int schoolYear;
 
     /**
@@ -15,10 +18,10 @@ public class GroupQuery {
     }
 
     /**
-     * @return The subject ids to query the group by
+     * @return The subjects to query the group by
      */
-    public Set<Integer> getSubjectIds() {
-        return subjectIds;
+    public Set<Subject> getSubjects() {
+        return subjects;
     }
 
     /**
@@ -34,7 +37,7 @@ public class GroupQuery {
 
     public static class Builder {
         private int schoolId;
-        private Set<Integer> subjectIds;
+        private Set<Subject> subjects;
         private int schoolYear;
 
         public Builder schoolId(final int schoolId) {
@@ -42,8 +45,8 @@ public class GroupQuery {
             return this;
         }
 
-        public Builder subjectIds(final Set<Integer> subjectIds) {
-            this.subjectIds = subjectIds;
+        public Builder subjectIds(final Set<Subject> subjectIds) {
+            this.subjects = ImmutableSet.copyOf(subjectIds);
             return this;
         }
 
@@ -53,10 +56,10 @@ public class GroupQuery {
         }
 
         public GroupQuery build() {
-            GroupQuery query = new GroupQuery();
+            final GroupQuery query = new GroupQuery();
 
             query.schoolId = schoolId;
-            query.subjectIds = subjectIds;
+            query.subjects = subjects;
             query.schoolYear = schoolYear;
 
             return query;

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupRepository.java
@@ -15,4 +15,10 @@ public interface GroupRepository {
      * @return all groups matching the provided query
      */
     List<Group> findAllByQuery(@NotNull PermissionScope permissionScope, @NotNull GroupQuery query);
+
+    /**
+     * @param permissionScope The user's permission scope
+     * @return all the distinct school years for groups this user has access to.
+     */
+    List<Integer> findAllDistinctSchoolYears(@NotNull PermissionScope permissionScope);
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
@@ -5,6 +5,7 @@ import org.opentestsystem.rdw.admin.common.security.PermissionScope;
 import org.opentestsystem.rdw.admin.model.Group;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
 import org.opentestsystem.rdw.admin.repository.GroupRepository;
+import org.opentestsystem.rdw.common.model.Subject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -12,9 +13,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.validation.constraints.NotNull;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static java.lang.Integer.parseInt;
 import static org.opentestsystem.rdw.admin.common.jdbc.QueryUtils.getSecurityParameters;
 
 @Repository
@@ -23,6 +28,9 @@ public class JdbcGroupRepository implements GroupRepository {
 
     @Value("${sql.group.findAllByQuery}")
     private String findAllQuery;
+
+    @Value("${sql.group.findAllDistinctSchoolYears}")
+    private String findAllDistinctSchoolYears;
 
     @Autowired
     JdbcGroupRepository(final NamedParameterJdbcTemplate template) {
@@ -36,20 +44,47 @@ public class JdbcGroupRepository implements GroupRepository {
                 new MapSqlParameterSource()
                         .addValues(getSecurityParameters(permissionScope))
                         .addValues(getQueryParameters(query)),
-                (row, index) -> Group.builder()
-                        .name(row.getString("group_name"))
-                        .schoolName(row.getString("school_name"))
-                        .schoolYear(row.getInt("school_year"))
-                        .subject(row.getString("subject_code"))
-                        .build()
+                (row, index) -> mapResultToGroup(row)
         );
+    }
+
+    @Override
+    public List<Integer> findAllDistinctSchoolYears(@NotNull final PermissionScope permissionScope) {
+        return template.query(
+                findAllDistinctSchoolYears,
+                getSecurityParameters(permissionScope),
+                (row, index) -> row.getInt("school_year")
+        );
+    }
+
+    private static Group mapResultToGroup(final ResultSet row) throws SQLException {
+        return Group.builder()
+                .name(row.getString("group_name"))
+                .schoolName(row.getString("school_name"))
+                .schoolYear(row.getInt("school_year"))
+                .subject(parseSubject(row.getString("subject_id")))
+                .build();
     }
 
     private static Map<String, Object> getQueryParameters(final GroupQuery query) {
         return ImmutableMap.<String, Object>builder()
                 .put("school_id", query.getSchoolId())
-                .put("subject_ids", query.getSubjectIds())
+                .put("subject_ids", query
+                        .getSubjects()
+                        .stream()
+                        .map(Subject::id)
+                        .collect(Collectors.toSet()))
                 .put("school_year", query.getSchoolYear())
                 .build();
+    }
+
+    private static Subject parseSubject(final String id) {
+        try {
+            return id == null
+                    ? null
+                    : Subject.valueOf(parseInt(id));
+        } catch (IllegalArgumentException ignore) {
+            return null;
+        }
     }
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/GroupService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/GroupService.java
@@ -1,13 +1,16 @@
 package org.opentestsystem.rdw.admin.service;
 
 import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupFilterOptions;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
 import org.opentestsystem.rdw.admin.security.User;
 import org.springframework.security.access.prepost.PreAuthorize;
 
-import java.util.List;
+import java.util.Set;
 
 @PreAuthorize("hasAuthority('PERM_GROUP_READ')")
 public interface GroupService {
-    List<Group> getByQuery(User user, GroupQuery query);
+    Set<Group> getByQuery(User user, GroupQuery query);
+
+    GroupFilterOptions getFilterOptions(User user);
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
@@ -1,27 +1,49 @@
 package org.opentestsystem.rdw.admin.service.impl;
 
+import com.google.common.collect.ImmutableSet;
 import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupFilterOptions;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
 import org.opentestsystem.rdw.admin.repository.GroupRepository;
 import org.opentestsystem.rdw.admin.security.User;
 import org.opentestsystem.rdw.admin.service.GroupService;
+import org.opentestsystem.rdw.admin.service.SchoolService;
+import org.opentestsystem.rdw.common.model.Subject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.Set;
 
 @Service
-public class DefaultGroupService implements GroupService {
+class DefaultGroupService implements GroupService {
+    private static final Set<Subject> SUBJECTS = ImmutableSet.copyOf(Subject.class.getEnumConstants());
 
     private final GroupRepository repository;
+    private final SchoolService schoolService;
 
     @Autowired
-    DefaultGroupService(GroupRepository repository) {
+    DefaultGroupService(final GroupRepository repository, final SchoolService schoolService) {
         this.repository = repository;
+        this.schoolService = schoolService;
     }
 
     @Override
-    public List<Group> getByQuery(final User user, final GroupQuery query) {
-        return repository.findAllByQuery(user.getPermissionsById().get("GROUP_READ").getScope(), query);
+    public Set<Group> getByQuery(final User user, final GroupQuery query) {
+        return ImmutableSet.copyOf(repository.findAllByQuery(user.getPermissionsById().get("GROUP_READ").getScope(), query));
+    }
+
+    @Override
+    public GroupFilterOptions getFilterOptions(final User user) {
+        return GroupFilterOptions
+                .builder()
+                .schools(schoolService.getSchools(user))
+                .subjects(SUBJECTS)
+                .schoolYears(ImmutableSet
+                        .copyOf(repository
+                                .findAllDistinctSchoolYears(user
+                                        .getPermissionsById()
+                                        .get("GROUP_READ")
+                                        .getScope())))
+                .build();
     }
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultSchoolService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultSchoolService.java
@@ -24,7 +24,7 @@ class DefaultSchoolService implements SchoolService {
 
     @Override
     public Set<Organization> getSchools(@NotNull final User user) {
-        final Permission permission = user.getPermissionsById().get("INDIVIDUAL_PII_READ");
+        final Permission permission = user.getPermissionsById().get("GROUP_READ");
         if (permission == null) {
             return ImmutableSet.of();
         }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupController.java
@@ -28,7 +28,7 @@ public class GroupController {
     }
 
     @GetMapping("/api/groups/filters")
-    public GroupFilterOptions get(@AuthenticationPrincipal final User user) {
+    public GroupFilterOptions getFilters(@AuthenticationPrincipal final User user) {
         return service.getFilterOptions(user);
     }
 

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupController.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupController.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.admin.web;
 
 import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupFilterOptions;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
 import org.opentestsystem.rdw.admin.security.User;
 import org.opentestsystem.rdw.admin.service.GroupService;
@@ -9,7 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import java.util.Set;
 
 @RestController
 public class GroupController {
@@ -17,13 +18,18 @@ public class GroupController {
     private final GroupService service;
 
     @Autowired
-    GroupController(GroupService service) {
+    GroupController(final GroupService service) {
         this.service = service;
     }
 
     @GetMapping("/api/groups")
-    public List<Group> get(@AuthenticationPrincipal final User user, GroupQuery query) {
+    public Set<Group> get(@AuthenticationPrincipal final User user, final GroupQuery query) {
         return service.getByQuery(user, query);
+    }
+
+    @GetMapping("/api/groups/filters")
+    public GroupFilterOptions get(@AuthenticationPrincipal final User user) {
+        return service.getFilterOptions(user);
     }
 
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
@@ -31,7 +31,7 @@ public class GroupQueryArgumentResolver implements HandlerMethodArgumentResolver
         return GroupQuery.builder()
                 .schoolId(parseInt(webRequest.getParameter("schoolId")))
                 .schoolYear(parseInt(webRequest.getParameter("schoolYear")))
-                .subjectIds(Stream
+                .subjects(Stream
                         .of(webRequest.getParameterValues("subject"))
                         .map(x-> {
                             try {

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/web/GroupQueryArgumentResolver.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.admin.web;
 
 import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.common.model.Subject;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -31,8 +32,15 @@ public class GroupQueryArgumentResolver implements HandlerMethodArgumentResolver
                 .schoolId(parseInt(webRequest.getParameter("schoolId")))
                 .schoolYear(parseInt(webRequest.getParameter("schoolYear")))
                 .subjectIds(Stream
-                        .of(webRequest.getParameterValues("subjectId"))
-                        .map(Integer::parseInt)
+                        .of(webRequest.getParameterValues("subject"))
+                        .map(x-> {
+                            try {
+                                return Subject.valueOf(x.toUpperCase());
+                            }
+                            catch(IllegalArgumentException ignore) {
+                                return null;
+                            }
+                        })
                         .collect(Collectors.toSet()))
                 .build();
     }

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -10,14 +10,19 @@ sql:
       where natural_id in (:naturalIds)
 
   group:
+    findAllDistinctSchoolYears: >-
+      select distinct sg.school_year
+      from student_group sg
+        join school sc on sc.id = sg.school_id
+      where 1=:statewide or sc.district_id in (:district_ids) or sg.school_id in (:school_ids)
+
     findAllByQuery: >-
       select sg.name as group_name,
         sc.name as school_name,
-        su.code as subject_code,
+        sg.subject_id,
         sg.school_year
       from student_group sg
         join school sc on sc.id = sg.school_id
-        left join subject su on su.id = sg.subject_id
       where sg.school_id = :school_id
         and (sg.subject_id is null or sg.subject_id in (:subject_ids))
         and sg.school_year = :school_year

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
@@ -36,7 +36,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(Subject.MATH))
+                .subjects(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(statewide(), query);
@@ -49,7 +49,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(Subject.ELA))
+                .subjects(ImmutableSet.of(Subject.ELA))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(statewide(), query);
@@ -62,7 +62,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(Subject.MATH))
+                .subjects(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(districts(-20L), query);
@@ -75,7 +75,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(Subject.MATH))
+                .subjects(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(schools(-20L), query);
@@ -88,7 +88,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(Subject.MATH))
+                .subjects(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(statewide(), query);

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.admin.model.Group;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
 import org.opentestsystem.rdw.admin.repository.RepositoryIT;
+import org.opentestsystem.rdw.common.model.Subject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -14,10 +15,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.opentestsystem.rdw.admin.common.test.support.PermissionScopes.districts;
 import static org.opentestsystem.rdw.admin.common.test.support.PermissionScopes.schools;
 import static org.opentestsystem.rdw.admin.common.test.support.PermissionScopes.statewide;
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RunWith(SpringRunner.class)
@@ -35,7 +36,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(1))
+                .subjectIds(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(statewide(), query);
@@ -48,7 +49,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(2))
+                .subjectIds(ImmutableSet.of(Subject.ELA))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(statewide(), query);
@@ -61,7 +62,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(1))
+                .subjectIds(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(districts(-20L), query);
@@ -74,7 +75,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(1))
+                .subjectIds(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(schools(-20L), query);
@@ -87,7 +88,7 @@ public class JdbcGroupRepositoryIT {
         GroupQuery query = GroupQuery.builder()
                 .schoolId(-10)
                 .schoolYear(2017)
-                .subjectIds(ImmutableSet.of(1))
+                .subjectIds(ImmutableSet.of(Subject.MATH))
                 .build();
 
         List<Group> actual = repository.findAllByQuery(statewide(), query);
@@ -99,7 +100,7 @@ public class JdbcGroupRepositoryIT {
                         Group.builder()
                                 .name("group1")
                                 .schoolName("school1")
-                                .subject("Math")
+                                .subject(Subject.MATH)
                                 .schoolYear(2017)
                                 .build());
         assertThat(actual.get(1))
@@ -110,5 +111,24 @@ public class JdbcGroupRepositoryIT {
                                 .schoolYear(2017)
                                 .build()
                 );
+    }
+
+    @Test
+    public void itShouldFindDistinctSchoolYears() {
+        List<Integer> actual = repository.findAllDistinctSchoolYears(statewide());
+
+        assertThat(actual)
+                .hasSize(2)
+                .contains(2017)
+                .contains(2016);
+    }
+
+    @Test
+    public void itShouldFindDistinctSchoolYearsWithOnlySchoolPermission() {
+        List<Integer> actual = repository.findAllDistinctSchoolYears(schools(-20L));
+
+        assertThat(actual)
+                .hasSize(1)
+                .contains(2016);
     }
 }

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/web/GroupControllerIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/web/GroupControllerIT.java
@@ -46,7 +46,7 @@ public class GroupControllerIT {
                         .builder()
                         .schoolId(1)
                         .schoolYear(2017)
-                        .subjectIds(ImmutableSet.of(Subject.ELA))
+                        .subjects(ImmutableSet.of(Subject.ELA))
                         .build()))
         ).thenReturn(ImmutableSet.of(
                 Group.builder()
@@ -70,7 +70,7 @@ public class GroupControllerIT {
                         .builder()
                         .schoolId(1)
                         .schoolYear(2017)
-                        .subjectIds(ImmutableSet.of(Subject.ELA, Subject.MATH))
+                        .subjects(ImmutableSet.of(Subject.ELA, Subject.MATH))
                         .build()))
         ).thenReturn(ImmutableSet.of(Group.builder()
                 .name("test1")

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/web/GroupControllerIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/web/GroupControllerIT.java
@@ -1,13 +1,15 @@
 package org.opentestsystem.rdw.admin.web;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.common.model.Organization;
 import org.opentestsystem.rdw.admin.model.Group;
+import org.opentestsystem.rdw.admin.model.GroupFilterOptions;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
 import org.opentestsystem.rdw.admin.security.User;
 import org.opentestsystem.rdw.admin.service.GroupService;
+import org.opentestsystem.rdw.common.model.Subject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -44,16 +46,16 @@ public class GroupControllerIT {
                         .builder()
                         .schoolId(1)
                         .schoolYear(2017)
-                        .subjectIds(ImmutableSet.of(1))
+                        .subjectIds(ImmutableSet.of(Subject.ELA))
                         .build()))
-        ).thenReturn(ImmutableList.of(
+        ).thenReturn(ImmutableSet.of(
                 Group.builder()
                         .name("test1")
                         .schoolName("school1")
-                        .subject("ELA")
+                        .subject(Subject.ELA)
                         .build()));
 
-        mvc.perform(get("/api/groups?schoolId=1&subjectId=1&schoolYear=2017")
+        mvc.perform(get("/api/groups?schoolId=1&subject=ELA&schoolYear=2017")
                 .with(user(user)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("test1"))
@@ -68,19 +70,40 @@ public class GroupControllerIT {
                         .builder()
                         .schoolId(1)
                         .schoolYear(2017)
-                        .subjectIds(ImmutableSet.of(1, 2))
+                        .subjectIds(ImmutableSet.of(Subject.ELA, Subject.MATH))
                         .build()))
-        ).thenReturn(ImmutableList.of(Group.builder()
+        ).thenReturn(ImmutableSet.of(Group.builder()
                 .name("test1")
                 .schoolName("school1")
-                .subject("ELA")
+                .subject(Subject.MATH)
                 .build()));
 
-        mvc.perform(get("/api/groups?schoolId=1&subjectId=1&subjectId=2&schoolYear=2017")
+        mvc.perform(get("/api/groups?schoolId=1&subject=ELA&subject=MATH&schoolYear=2017")
                 .with(user(user)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("test1"))
                 .andExpect(jsonPath("$[0].schoolName").value("school1"))
-                .andExpect(jsonPath("$[0].subject").value("ELA"));
+                .andExpect(jsonPath("$[0].subject").value("MATH"));
+    }
+
+    @Test
+    public void itShouldGetFilters() throws Exception {
+        when(service.getFilterOptions(any(User.class)))
+                .thenReturn(GroupFilterOptions.builder()
+                        .schools(ImmutableSet.of(new Organization(1, "school1")))
+                        .subjects(ImmutableSet.of(Subject.MATH, Subject.ELA))
+                        .schoolYears(ImmutableSet.of(2016, 2017, 2018))
+                        .build());
+
+        mvc.perform(get("/api/groups/filters")
+                .with(user(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.schools[0].name").value("school1"))
+                .andExpect(jsonPath("$.subjects[0]").value("MATH"))
+                .andExpect(jsonPath("$.subjects[1]").value("ELA"))
+                .andExpect(jsonPath("$.schoolYears[0]").value("2016"))
+                .andExpect(jsonPath("$.schoolYears[1]").value("2017"))
+                .andExpect(jsonPath("$.schoolYears[2]").value("2018"));
+
     }
 }

--- a/webapp/src/test/resources/integration-test-data.sql
+++ b/webapp/src/test/resources/integration-test-data.sql
@@ -28,7 +28,9 @@ insert into student (id, ssid, last_or_surname, first_name, gender_id, birthday,
 
 insert into student_group (id, name, school_id, school_year, subject_id, import_id, update_import_id, active) values
   (-10, 'group1', -10, 2017, 1, -1, -1, 1),
-  (-20, 'group2', -10, 2017, null, -1, -1, 1);
+  (-20, 'group2', -10, 2017, null, -1, -1, 1),
+  (-30, 'group2', -20, 2016, null, -1, -1, 1);
+
 
 insert into student_group_membership (student_group_id, student_id) values
   (-10, -1);


### PR DESCRIPTION
… subjects in which the groups can be queried by.

 - Implemented peer review comments
 - Now using Subject enum all around both api endpoints
 - Added IT for new repo and controller methods.

Example api: 
`api/groups/filters`

which returns
```
{"schools":[
   {"id":1,"name":"Siamang Attila Senior High"},
   {"id":2,"name":"Galloway Motmot Elementary"},
   {"id":3,"name":"Kangaroo Wren Sch"},
   {"id":4,"name":"Wallaby Ginko MS"},
   {"id":5,"name":"Parakeet Vireo Jr Middle"},
   {"id":6,"name":"Winterhazel Becard El Sch"}],
"schoolYears":[2015,2017,2018],
"subjects":["MATH","ELA"]}
```