### PR TITLE
Migrate group deletions to the data-mart

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupImportRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupImportRepository.java
@@ -6,8 +6,8 @@ package org.opentestsystem.rdw.admin.repository;
 public interface GroupImportRepository {
 
     /**
-     * Create a Import record to represent a warehouse
-     * to data-mart Group migration.
+     * Create an Import record to associate with new group data;
+     * the record is created with status ACCEPTED
      *
      * @param digest    The import digest (max 32-character string)
      * @param batch     The import batch (max 250-character string)
@@ -16,9 +16,9 @@ public interface GroupImportRepository {
     long create(String digest, String batch);
 
     /**
-     * Trigger the given Import.
+     * Update the given Import record to the PROCESSED status.
      *
      * @param importId The import id
      */
-    void trigger(long importId);
+    void setProcessed(long importId);
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupImportRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupImportRepository.java
@@ -1,0 +1,24 @@
+package org.opentestsystem.rdw.admin.repository;
+
+/**
+ * This repository is responsible for working with imports.
+ */
+public interface GroupImportRepository {
+
+    /**
+     * Create a Import record to represent a warehouse
+     * to data-mart Group migration.
+     *
+     * @param digest    The import digest (max 32-character string)
+     * @param batch     The import batch (max 250-character string)
+     * @return The created import id
+     */
+    long create(String digest, String batch);
+
+    /**
+     * Trigger the given Import.
+     *
+     * @param importId The import id
+     */
+    void trigger(long importId);
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/GroupRepository.java
@@ -26,6 +26,9 @@ public interface GroupRepository {
      * Deletes the group if the permission scope allows
      * @param permissionScope   The user's permission scope
      * @param id                The group id being deleted
+     * @param importId          The associated import for migrating the change
      */
-    void delete(@NotNull PermissionScope permissionScope, @NotNull long id);
+    void delete(PermissionScope permissionScope,
+                long id,
+                long importId);
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepository.java
@@ -1,0 +1,51 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import org.opentestsystem.rdw.admin.repository.GroupImportRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+/**
+ * JDBC-backed implementation of a GroupImportRepository.
+ */
+@Repository
+public class JdbcGroupImportRepository implements GroupImportRepository {
+
+    private final NamedParameterJdbcTemplate template;
+
+    @Value("${sql.import.createQuery}")
+    private String createQuery;
+
+    @Value("${sql.import.triggerQuery}")
+    private String triggerQuery;
+
+    @Autowired
+    public JdbcGroupImportRepository(final NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
+
+    @Override
+    public long create(final String digest, final String batch) {
+        final KeyHolder keyHolder = new GeneratedKeyHolder();
+        final SqlParameterSource parameterSource = new MapSqlParameterSource()
+                .addValue("digest", digest)
+                .addValue("batch", batch);
+
+        template.update(createQuery, parameterSource, keyHolder);
+
+        return keyHolder.getKey().longValue();
+    }
+
+    @Override
+    public void trigger(final long importId) {
+        template.update(
+                triggerQuery,
+                new MapSqlParameterSource()
+                        .addValue("import_id", importId));
+    }
+}

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepository.java
@@ -42,7 +42,7 @@ public class JdbcGroupImportRepository implements GroupImportRepository {
     }
 
     @Override
-    public void trigger(final long importId) {
+    public void setProcessed(final long importId) {
         template.update(
                 triggerQuery,
                 new MapSqlParameterSource()

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepository.java
@@ -62,12 +62,15 @@ public class JdbcGroupRepository implements GroupRepository {
     }
 
     @Override
-    public void delete(@NotNull final PermissionScope permissionScope, @NotNull final long id) {
+    public void delete(final PermissionScope permissionScope,
+                       final long id,
+                       final long importId) {
         final int result = template.update(
                 deleteSql,
                 new MapSqlParameterSource()
                         .addValues(getSecurityParameters(permissionScope))
                         .addValue("id", id)
+                        .addValue("import_id", importId)
         );
 
         if(result == 0)

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
@@ -61,6 +61,6 @@ class DefaultGroupService implements GroupService {
         final String digest = HexUtils.toHexString(DigestUtils.md5(user.getEmail() + id));
         final long importId = importRepository.create(digest, "group delete");
         repository.delete(user.getPermissionsById().get("GROUP_WRITE").getScope(), id, importId);
-        importRepository.trigger(importId);
+        importRepository.setProcessed(importId);
     }
 }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupService.java
@@ -1,9 +1,12 @@
 package org.opentestsystem.rdw.admin.service.impl;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.tomcat.util.buf.HexUtils;
 import org.opentestsystem.rdw.admin.model.Group;
 import org.opentestsystem.rdw.admin.model.GroupFilterOptions;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.repository.GroupImportRepository;
 import org.opentestsystem.rdw.admin.repository.GroupRepository;
 import org.opentestsystem.rdw.admin.security.User;
 import org.opentestsystem.rdw.admin.service.GroupService;
@@ -11,6 +14,7 @@ import org.opentestsystem.rdw.admin.service.SchoolService;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
 
@@ -19,11 +23,15 @@ class DefaultGroupService implements GroupService {
     private static final Set<Subject> SUBJECTS = ImmutableSet.copyOf(Subject.class.getEnumConstants());
 
     private final GroupRepository repository;
+    private final GroupImportRepository importRepository;
     private final SchoolService schoolService;
 
     @Autowired
-    DefaultGroupService(final GroupRepository repository, final SchoolService schoolService) {
+    DefaultGroupService(final GroupRepository repository,
+                        final GroupImportRepository importRepository,
+                        final SchoolService schoolService) {
         this.repository = repository;
+        this.importRepository = importRepository;
         this.schoolService = schoolService;
     }
 
@@ -48,7 +56,11 @@ class DefaultGroupService implements GroupService {
     }
 
     @Override
+    @Transactional
     public void delete(final User user, final long id) {
-        repository.delete(user.getPermissionsById().get("GROUP_WRITE").getScope(), id);
+        final String digest = HexUtils.toHexString(DigestUtils.md5(user.getEmail() + id));
+        final long importId = importRepository.create(digest, "group delete");
+        repository.delete(user.getPermissionsById().get("GROUP_WRITE").getScope(), id, importId);
+        importRepository.trigger(importId);
     }
 }

--- a/webapp/src/main/resources/application.sql.yml
+++ b/webapp/src/main/resources/application.sql.yml
@@ -35,7 +35,8 @@ sql:
     delete: >-
       update student_group sg
         join school s on sg.school_id = s.id
-      set sg.deleted = 1
+      set sg.deleted = 1,
+        sg.update_import_id = :import_id
       where sg.id = :id
         and (1=:statewide or s.district_id in (:district_ids) or sg.school_id in (:school_ids))
 
@@ -67,3 +68,13 @@ sql:
 
     sqlFindByCreator: >-
       SELECT * FROM upload_student_group_batch WHERE creator=:creator
+
+  import:
+    createQuery: >-
+      INSERT INTO import (status, content, contentType, digest, batch) VALUES
+        (0, 5, 'admin group modification', :digest, :batch)
+
+    triggerQuery: >-
+      UPDATE import
+      SET status = 1
+      WHERE id = :import_id

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/CsvGenerator.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/CsvGenerator.java
@@ -30,15 +30,30 @@ import static org.opentestsystem.rdw.admin.service.impl.DefaultCsvValidationServ
 public class CsvGenerator {
     private static final Logger logger = LoggerFactory.getLogger(CsvGenerator.class);
 
-    private static final int NumGroupsPerSchool = 4500; //4500
+    private static final int NumGroupsPerSchool = 1000; //4500
     private static final int NumStudentsPerGroup = 30;
     private static final String output = "file:///tmp/output.csv";
     private static final List<String> SchoolIds = newArrayList(
-            "aefa599e5edc4e8fb9c516224a8a37",
-            "8f7097f6dc8f4067af4bb1260ef0b0",
-            "495316f47b524f728ab280491e7f42",
+            "0cf31b8fe2f84a34bdc4331b35906e",
+            "0e24e625687242a19891b7aab79be6",
+            "10e502b720e84f23a87eb35a8926b8",
+            "2c40f8bc1f1f4b34885fb7acc781f5",
             "3461a7012fe54bd3a197eb0d2c462f",
-            "0cf31b8fe2f84a34bdc4331b35906e"
+            "495316f47b524f728ab280491e7f42",
+            "7354ce8f9adc41c4908a8a5d859c5e",
+            "8f7097f6dc8f4067af4bb1260ef0b0",
+            "961ac82c54164b06a56bad28eb76d6",
+            "a7246df055a146f8b7aefe58d4c366",
+            "ad99f307097347ef910cb217573d78",
+            "aefa599e5edc4e8fb9c516224a8a37",
+            "b6647223fd8742d7afadffe1eb768e",
+            "b72fbea3769e41ca937208dd27f8d2",
+            "bf783171a7a44f80b7be6f30721c91",
+            "d8bb1a9ba9fc4ef0a076169babc051",
+            "e8c7e6ab1bf240bd858353de330f33",
+            "eb558506c9fe496b9bff7693ab676a",
+            "ec793209fc7f4029a7e96d3beb20a1",
+            "f7fc61a4c89b435fb18e8d705c8dab"
     );
 
     private static final List<String> OrderedHeaders = newArrayList(RequiredHeaders);

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/CsvGenerator.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/CsvGenerator.java
@@ -30,30 +30,15 @@ import static org.opentestsystem.rdw.admin.service.impl.DefaultCsvValidationServ
 public class CsvGenerator {
     private static final Logger logger = LoggerFactory.getLogger(CsvGenerator.class);
 
-    private static final int NumGroupsPerSchool = 1000; //4500
+    private static final int NumGroupsPerSchool = 4500; //4500
     private static final int NumStudentsPerGroup = 30;
     private static final String output = "file:///tmp/output.csv";
     private static final List<String> SchoolIds = newArrayList(
-            "0cf31b8fe2f84a34bdc4331b35906e",
-            "0e24e625687242a19891b7aab79be6",
-            "10e502b720e84f23a87eb35a8926b8",
-            "2c40f8bc1f1f4b34885fb7acc781f5",
-            "3461a7012fe54bd3a197eb0d2c462f",
-            "495316f47b524f728ab280491e7f42",
-            "7354ce8f9adc41c4908a8a5d859c5e",
-            "8f7097f6dc8f4067af4bb1260ef0b0",
-            "961ac82c54164b06a56bad28eb76d6",
-            "a7246df055a146f8b7aefe58d4c366",
-            "ad99f307097347ef910cb217573d78",
             "aefa599e5edc4e8fb9c516224a8a37",
-            "b6647223fd8742d7afadffe1eb768e",
-            "b72fbea3769e41ca937208dd27f8d2",
-            "bf783171a7a44f80b7be6f30721c91",
-            "d8bb1a9ba9fc4ef0a076169babc051",
-            "e8c7e6ab1bf240bd858353de330f33",
-            "eb558506c9fe496b9bff7693ab676a",
-            "ec793209fc7f4029a7e96d3beb20a1",
-            "f7fc61a4c89b435fb18e8d705c8dab"
+            "8f7097f6dc8f4067af4bb1260ef0b0",
+            "495316f47b524f728ab280491e7f42",
+            "3461a7012fe54bd3a197eb0d2c462f",
+            "0cf31b8fe2f84a34bdc4331b35906e"
     );
 
     private static final List<String> OrderedHeaders = newArrayList(RequiredHeaders);

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepositoryIT.java
@@ -1,0 +1,54 @@
+package org.opentestsystem.rdw.admin.repository.impl;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opentestsystem.rdw.admin.repository.GroupImportRepository;
+import org.opentestsystem.rdw.admin.repository.RepositoryIT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@RepositoryIT
+@ContextConfiguration(classes = {JdbcGroupImportRepository.class})
+@Sql(scripts = {"classpath:integration-test-data.sql"})
+@ActiveProfiles("test")
+public class JdbcGroupImportRepositoryIT {
+
+    @Autowired
+    public GroupImportRepository repository;
+
+    @Autowired
+    public NamedParameterJdbcTemplate template;
+
+    @Test
+    public void itShouldCreateAnImport() {
+        final long importId = repository.create("digest", "batch");
+
+        final Map<String, Object> importMap = template.queryForMap(
+                "SELECT * from import where id = :import_id",
+                ImmutableMap.of("import_id", importId));
+
+        assertThat(importMap.get("status")).isEqualTo(0);
+    }
+
+    @Test
+    public void itShouldTriggerAnImport() {
+        final long importId = repository.create("digest", "batch");
+        repository.trigger(importId);
+
+        final Map<String, Object> importMap = template.queryForMap(
+                "SELECT * from import where id = :import_id",
+                ImmutableMap.of("import_id", importId));
+
+        assertThat(importMap.get("status")).isEqualTo(1);
+    }
+}

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupImportRepositoryIT.java
@@ -43,7 +43,7 @@ public class JdbcGroupImportRepositoryIT {
     @Test
     public void itShouldTriggerAnImport() {
         final long importId = repository.create("digest", "batch");
-        repository.trigger(importId);
+        repository.setProcessed(importId);
 
         final Map<String, Object> importMap = template.queryForMap(
                 "SELECT * from import where id = :import_id",

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/repository/impl/JdbcGroupRepositoryIT.java
@@ -1,19 +1,23 @@
 package org.opentestsystem.rdw.admin.repository.impl;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opentestsystem.rdw.admin.model.Group;
 import org.opentestsystem.rdw.admin.model.GroupQuery;
+import org.opentestsystem.rdw.admin.repository.GroupImportRepository;
 import org.opentestsystem.rdw.admin.repository.RepositoryIT;
 import org.opentestsystem.rdw.common.model.Subject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,13 +28,22 @@ import static org.opentestsystem.rdw.admin.common.test.support.PermissionScopes.
 
 @RunWith(SpringRunner.class)
 @RepositoryIT
-@ContextConfiguration(classes = {JdbcGroupRepository.class})
+@ContextConfiguration(classes = {
+        JdbcGroupRepository.class,
+        JdbcGroupImportRepository.class
+})
 @Sql(scripts = {"classpath:integration-test-data.sql"})
 @ActiveProfiles("test")
 public class JdbcGroupRepositoryIT {
 
     @Autowired
     JdbcGroupRepository repository;
+
+    @Autowired
+    GroupImportRepository importRepository;
+
+    @Autowired
+    NamedParameterJdbcTemplate template;
 
     @Test
     public void itShouldFindByQuery() {
@@ -150,15 +163,21 @@ public class JdbcGroupRepositoryIT {
         assertThat(actual).hasSize(2);
         assertThat(actual.get(0).getId()).isEqualTo(-10);
 
-        repository.delete(statewide(), -10);
+        final long importId = importRepository.create("digest", "batch");
+        repository.delete(statewide(), -10, importId);
         actual = repository.findAllByQuery(statewide(), query);
 
         assertThat(actual).hasSize(1);
         assertThat(actual.get(0).getId()).isNotEqualTo(-10);
+
+        final Map<String, Object> groupMap = template.queryForMap(
+                "SELECT * from student_group WHERE id = -10",
+                ImmutableMap.of());
+        assertThat(groupMap.get("update_import_id")).isEqualTo(importId);
     }
 
     @Test(expected = NoSuchElementException.class)
     public void itShouldThrowIfNotUpdated() {
-        repository.delete(schools(-50L), -10);
+        repository.delete(schools(-50L), -10, 123);
     }
 }

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupServiceTest.java
@@ -56,7 +56,7 @@ public class DefaultGroupServiceTest {
 
         service.delete(user, groupId);
         verify(repository).delete(STATEWIDE, groupId, importId);
-        verify(importRepository).trigger(importId);
+        verify(importRepository).setProcessed(importId);
     }
 
 }

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultGroupServiceTest.java
@@ -1,0 +1,62 @@
+package org.opentestsystem.rdw.admin.service.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.rdw.admin.repository.GroupImportRepository;
+import org.opentestsystem.rdw.admin.repository.GroupRepository;
+import org.opentestsystem.rdw.admin.security.Permission;
+import org.opentestsystem.rdw.admin.security.User;
+import org.opentestsystem.rdw.admin.service.SchoolService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opentestsystem.rdw.admin.common.security.PermissionScope.STATEWIDE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultGroupServiceTest {
+
+    @Mock
+    public GroupRepository repository;
+
+    @Mock
+    public GroupImportRepository importRepository;
+
+    @Mock
+    public SchoolService schoolService;
+
+    @Mock
+    public User user;
+
+    private DefaultGroupService service;
+
+    @Before
+    public void setup() {
+        service = new DefaultGroupService(repository, importRepository, schoolService);
+
+        final Map<String, Permission> permissions = new HashMap<>();
+        final Permission permission = new Permission("GROUP_WRITE", STATEWIDE);
+        permissions.put("GROUP_WRITE", permission);
+        when(user.getPermissionsById()).thenReturn(permissions);
+    }
+
+    @Test
+    public void itShouldDeleteAGroupWithAnImport() {
+        final long importId = 123L;
+        when(importRepository.create(anyString(), eq("group delete")))
+                .thenReturn(importId);
+        final long groupId = 456L;
+
+        service.delete(user, groupId);
+        verify(repository).delete(STATEWIDE, groupId, importId);
+        verify(importRepository).trigger(importId);
+    }
+
+}


### PR DESCRIPTION
This PR creates an import record on group deletion, sets the deleted group's update_import_id to the new import record, then marks the import as ready.