### PR TITLE
DWR-929 Validate CSV header order on upload

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/CsvValidationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/CsvValidationService.java
@@ -6,7 +6,7 @@ import org.opentestsystem.rdw.admin.model.CsvValidationFailure;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * Implementations of this interface are responsible for validating
@@ -18,10 +18,10 @@ public interface CsvValidationService {
      * Validate the given CSV's headers and return the collection
      * of validation failures.
      *
-     * @param csvHeaders CSV headers
+     * @param csvHeaders The map of CSV header to index
      * @return The list of validation failures, empty if valid
      */
-    List<CsvValidationFailure> validateHeaders(Set<String> csvHeaders);
+    List<CsvValidationFailure> validateHeaders(Map<String, Integer> csvHeaders);
 
     /**
      * Validate the given CSV records and return the collection

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/CsvValidationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/CsvValidationService.java
@@ -6,7 +6,6 @@ import org.opentestsystem.rdw.admin.model.CsvValidationFailure;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Implementations of this interface are responsible for validating
@@ -18,10 +17,10 @@ public interface CsvValidationService {
      * Validate the given CSV's headers and return the collection
      * of validation failures.
      *
-     * @param csvHeaders The map of CSV header to index
+     * @param csvHeaders The ordered list of CSV headers
      * @return The list of validation failures, empty if valid
      */
-    List<CsvValidationFailure> validateHeaders(Map<String, Integer> csvHeaders);
+    List<CsvValidationFailure> validateHeaders(List<String> csvHeaders);
 
     /**
      * Validate the given CSV records and return the collection

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.rdw.admin.service.impl;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import org.apache.commons.csv.CSVRecord;
 import org.opentestsystem.rdw.admin.common.model.Organization;
 import org.opentestsystem.rdw.admin.common.security.PermissionScope;
@@ -15,10 +16,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.Sets.newHashSet;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -28,20 +29,20 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 @Service
 public class DefaultCsvValidationService implements CsvValidationService {
 
-    public final static String HeaderSchool = "school_natural_id";
-    public final static String HeaderSubject = "subject_code";
     public final static String HeaderGroup = "group_name";
-    public final static String HeaderUser = "group_user_login";
+    public final static String HeaderSchool = "school_natural_id";
     public final static String HeaderYear = "school_year";
+    public final static String HeaderSubject = "subject_code";
     public final static String HeaderSSID = "student_ssid";
+    public final static String HeaderUser = "group_user_login";
 
-    public final static Set<String> RequiredHeaders = ImmutableSet.of(
-            HeaderSchool,
-            HeaderSubject,
+    public final static List<String> RequiredHeaders = ImmutableList.of(
             HeaderGroup,
-            HeaderUser,
+            HeaderSchool,
             HeaderYear,
-            HeaderSSID
+            HeaderSubject,
+            HeaderSSID,
+            HeaderUser
     );
 
     private static final String ValidationFormat = "Row: %1$d Failure: %2$s\n";
@@ -57,16 +58,20 @@ public class DefaultCsvValidationService implements CsvValidationService {
     }
 
     @Override
-    public List<CsvValidationFailure> validateHeaders(final Set<String> csvHeaders) {
+    public List<CsvValidationFailure> validateHeaders(final Map<String, Integer> csvHeaders) {
         final List<CsvValidationFailure> failures = new ArrayList<>();
-        final Set<String> headers = csvHeaders.stream().map(String::toLowerCase).collect(Collectors.toSet());
-        if (!headers.containsAll(RequiredHeaders)) {
-            final Set<String> missing = newHashSet(RequiredHeaders);
-            missing.removeAll(headers);
-            failures.add(CsvValidationFailure.builder()
-                    .row(0)
-                    .message("Missing headers " + missing)
-                    .build());
+
+        for (int i = 0; i < RequiredHeaders.size(); i++) {
+            final String header = RequiredHeaders.get(i);
+            if (!csvHeaders.containsKey(header) || csvHeaders.get(header) != i) {
+                failures.add(CsvValidationFailure.builder()
+                        .row(0)
+                        .message("Invalid headers. Headers must be in order: [" +
+                                Joiner.on(",").join(RequiredHeaders) +
+                                "]")
+                        .build());
+                break;
+            }
         }
         return failures;
     }

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,12 +57,11 @@ public class DefaultCsvValidationService implements CsvValidationService {
     }
 
     @Override
-    public List<CsvValidationFailure> validateHeaders(final Map<String, Integer> csvHeaders) {
+    public List<CsvValidationFailure> validateHeaders(final List<String> csvHeaders) {
         final List<CsvValidationFailure> failures = new ArrayList<>();
 
         for (int i = 0; i < RequiredHeaders.size(); i++) {
-            final String header = RequiredHeaders.get(i);
-            if (!csvHeaders.containsKey(header) || csvHeaders.get(header) != i) {
+            if (!RequiredHeaders.get(i).equalsIgnoreCase(csvHeaders.get(i))) {
                 failures.add(CsvValidationFailure.builder()
                         .row(0)
                         .message("Invalid headers. Headers must be in order: [" +

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
@@ -37,6 +37,7 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 @Service
@@ -172,7 +173,11 @@ class DefaultStudentGroupBatchService implements StudentGroupBatchService {
                 return validationFailures;
             }
 
-            validationFailures.addAll(validationService.validateHeaders(parser.getHeaderMap()));
+            final List<String> orderedHeaders = new ArrayList<>(parser.getHeaderMap().size());
+            for (final Map.Entry<String, Integer> entry : parser.getHeaderMap().entrySet()) {
+                orderedHeaders.add(entry.getValue(), entry.getKey());
+            }
+            validationFailures.addAll(validationService.validateHeaders(orderedHeaders));
             validationFailures.addAll(validationService.validateRecords(recordIterator, permissionScope));
 
         } catch (final IOException ex) {

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
@@ -172,7 +172,7 @@ class DefaultStudentGroupBatchService implements StudentGroupBatchService {
                 return validationFailures;
             }
 
-            validationFailures.addAll(validationService.validateHeaders(parser.getHeaderMap().keySet()));
+            validationFailures.addAll(validationService.validateHeaders(parser.getHeaderMap()));
             validationFailures.addAll(validationService.validateRecords(recordIterator, permissionScope));
 
         } catch (final IOException ex) {

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/CsvGenerator.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/CsvGenerator.java
@@ -56,19 +56,20 @@ public class CsvGenerator {
             "f7fc61a4c89b435fb18e8d705c8dab"
     );
 
-    private static final List<String> OrderedHeaders = newArrayList(RequiredHeaders);
     private static final String GroupPrefix = "Group_";
 
     public static void main(final String[] args) throws Exception {
 
         final URI uri = URI.create(output);
         final File file = new File(uri);
-        file.createNewFile();
+        if (!file.createNewFile()) {
+            throw new IllegalStateException("Unable to create output file");
+        }
 
         final CSVFormat format = CSVFormat.DEFAULT
                 .withFirstRecordAsHeader()
                 .withSkipHeaderRecord(false)
-                .withHeader(OrderedHeaders.toArray(new String[OrderedHeaders.size()]));
+                .withHeader(RequiredHeaders.toArray(new String[RequiredHeaders.size()]));
         final Map<String, String> recordValues = new HashMap<>();
         recordValues.put(HeaderYear, "2017");
 
@@ -106,8 +107,8 @@ public class CsvGenerator {
     }
 
     private static void printRow(final CSVPrinter printer, final Map<String, String> row) throws IOException {
-        final List<String> values = new ArrayList<>(OrderedHeaders.size());
-        for (final String header : OrderedHeaders) {
+        final List<String> values = new ArrayList<>(RequiredHeaders.size());
+        for (final String header : RequiredHeaders) {
             values.add(row.get(header));
         }
         printer.printRecord(values);

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
@@ -46,7 +46,6 @@ public class DefaultCsvValidationServiceTest {
     private SchoolRepository schoolRepository;
 
     private DefaultCsvValidationService service;
-    private Map<String, Integer> headerMap;
 
     @Before
     public void setup() {
@@ -56,23 +55,19 @@ public class DefaultCsvValidationServiceTest {
         when(schoolRepository.findAll(PermissionScope.STATEWIDE)).thenReturn(schools);
 
         service = new DefaultCsvValidationService(schoolRepository);
-
-        headerMap = new HashMap<>();
-        for (int i = 0; i < RequiredHeaders.size(); i++) {
-            headerMap.put(RequiredHeaders.get(i), i);
-        }
     }
 
     @Test
     public void itShouldValidateRequiredHeaders() {
-        assertThat(service.validateHeaders(headerMap)).isEmpty();
+        assertThat(service.validateHeaders(RequiredHeaders)).isEmpty();
     }
 
     @Test
     public void itShouldNotValidateMissingHeaders() {
-        headerMap.remove(RequiredHeaders.get(0));
+        final List<String> missingHeaders = newArrayList(RequiredHeaders);
+        missingHeaders.remove(0);
 
-        final CsvValidationFailure failure = service.validateHeaders(headerMap).get(0);
+        final CsvValidationFailure failure = service.validateHeaders(missingHeaders).get(0);
 
         assertThat(failure.getRow()).isEqualTo(0);
         assertThat(failure.getMessage()).contains(Joiner.on(",").join(RequiredHeaders));
@@ -82,12 +77,8 @@ public class DefaultCsvValidationServiceTest {
     public void itShouldNotValidateOutOfOrderHeaders() {
         final List<String> misOrderedHeaders = newLinkedList(RequiredHeaders);
         misOrderedHeaders.add(misOrderedHeaders.remove(0));
-        headerMap = new HashMap<>();
-        for (int i = 0; i < misOrderedHeaders.size(); i++) {
-            headerMap.put(misOrderedHeaders.get(i), i);
-        }
 
-        final CsvValidationFailure failure = service.validateHeaders(headerMap).get(0);
+        final CsvValidationFailure failure = service.validateHeaders(misOrderedHeaders).get(0);
 
         assertThat(failure.getRow()).isEqualTo(0);
         assertThat(failure.getMessage()).contains(Joiner.on(",").join(RequiredHeaders));

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.rdw.admin.service.impl;
 
+import com.google.common.base.Joiner;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
@@ -19,10 +20,9 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
+import static com.google.common.collect.Lists.newLinkedList;
 import static org.apache.commons.lang.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -41,12 +41,12 @@ public class DefaultCsvValidationServiceTest {
     private static final String GroupA = "GROUP_A";
     private static final String GroupB = "GROUP_B";
     private static final int SchoolYear = 2017;
-    private static final List<String> OrderedHeaders = newArrayList(RequiredHeaders);
 
     @Mock
-    public SchoolRepository schoolRepository;
+    private SchoolRepository schoolRepository;
 
     private DefaultCsvValidationService service;
+    private Map<String, Integer> headerMap;
 
     @Before
     public void setup() {
@@ -56,22 +56,41 @@ public class DefaultCsvValidationServiceTest {
         when(schoolRepository.findAll(PermissionScope.STATEWIDE)).thenReturn(schools);
 
         service = new DefaultCsvValidationService(schoolRepository);
+
+        headerMap = new HashMap<>();
+        for (int i = 0; i < RequiredHeaders.size(); i++) {
+            headerMap.put(RequiredHeaders.get(i), i);
+        }
     }
 
     @Test
     public void itShouldValidateRequiredHeaders() {
-        assertThat(service.validateHeaders(RequiredHeaders)).isEmpty();
+        assertThat(service.validateHeaders(headerMap)).isEmpty();
     }
 
     @Test
     public void itShouldNotValidateMissingHeaders() {
-        final Set<String> missingHeaders = newHashSet(RequiredHeaders);
-        missingHeaders.remove(HeaderSchool);
+        headerMap.remove(RequiredHeaders.get(0));
 
-        final CsvValidationFailure failure = service.validateHeaders(missingHeaders).get(0);
+        final CsvValidationFailure failure = service.validateHeaders(headerMap).get(0);
 
         assertThat(failure.getRow()).isEqualTo(0);
-        assertThat(failure.getMessage()).contains(HeaderSchool);
+        assertThat(failure.getMessage()).contains(Joiner.on(",").join(RequiredHeaders));
+    }
+
+    @Test
+    public void itShouldNotValidateOutOfOrderHeaders() {
+        final List<String> misOrderedHeaders = newLinkedList(RequiredHeaders);
+        misOrderedHeaders.add(misOrderedHeaders.remove(0));
+        headerMap = new HashMap<>();
+        for (int i = 0; i < misOrderedHeaders.size(); i++) {
+            headerMap.put(misOrderedHeaders.get(i), i);
+        }
+
+        final CsvValidationFailure failure = service.validateHeaders(headerMap).get(0);
+
+        assertThat(failure.getRow()).isEqualTo(0);
+        assertThat(failure.getMessage()).contains(Joiner.on(",").join(RequiredHeaders));
     }
 
     @Test
@@ -197,7 +216,7 @@ public class DefaultCsvValidationServiceTest {
                 final CSVFormat format = CSVFormat.DEFAULT
                         .withIgnoreHeaderCase()
                         .withFirstRecordAsHeader()
-                        .withHeader(OrderedHeaders.toArray(new String[OrderedHeaders.size()]));
+                        .withHeader(RequiredHeaders.toArray(new String[RequiredHeaders.size()]));
                 final CSVPrinter printer = new CSVPrinter(csvBuilder, format.withSkipHeaderRecord(false));
                 for (final List<String> record : records) {
                     printer.printRecord(record);
@@ -210,11 +229,11 @@ public class DefaultCsvValidationServiceTest {
             }
         }
 
-        public RecordBuilder row(final String school, final String group) {
+        RecordBuilder row(final String school, final String group) {
             return row(school, group, SchoolYear, null, null);
         }
 
-        public RecordBuilder row(final String school,
+        RecordBuilder row(final String school,
                                  final String group,
                                  final int schoolYear,
                                  final CsvSubject subject,
@@ -227,7 +246,7 @@ public class DefaultCsvValidationServiceTest {
             record.put(HeaderSSID, studentSSID);
 
             final List<String> values = newArrayList();
-            for (final String header : OrderedHeaders) {
+            for (final String header : RequiredHeaders) {
                 values.add(record.get(header));
             }
             records.add(values);

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchServiceTest.java
@@ -33,7 +33,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anySetOf;
+import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -69,7 +69,7 @@ public class DefaultStudentGroupBatchServiceTest {
         source = mock(GroupsSource.class);
         validationService = mock(CsvValidationService.class);
         when(validationService.toMessage(anyListOf(CsvValidationFailure.class))).thenReturn("message");
-        when(validationService.validateHeaders(anySetOf(String.class))).thenReturn(emptyList());
+        when(validationService.validateHeaders(anyMapOf(String.class, Integer.class))).thenReturn(emptyList());
         when(validationService.validateRecords(any(Iterator.class), any(PermissionScope.class)))
                 .thenAnswer(invocation -> {
                     final Iterator<CSVRecord> recordIterator = (Iterator<CSVRecord>) invocation.getArgumentAt(0, Iterator.class);
@@ -113,7 +113,7 @@ public class DefaultStudentGroupBatchServiceTest {
     public void itShouldNotUploadIfColumnHeadersAreMissing() throws IOException {
         final String payload = payload(ValidHeaders, ValidValues);
         when(file.getInputStream()).thenReturn(new ByteArrayInputStream(payload.getBytes()));
-        when(validationService.validateHeaders(anySetOf(String.class)))
+        when(validationService.validateHeaders(anyMapOf(String.class, Integer.class)))
                 .thenReturn(Collections.singletonList(CsvValidationFailure.builder()
                         .row(0)
                         .message("Bad stuffs")

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchServiceTest.java
@@ -33,7 +33,6 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -69,7 +68,7 @@ public class DefaultStudentGroupBatchServiceTest {
         source = mock(GroupsSource.class);
         validationService = mock(CsvValidationService.class);
         when(validationService.toMessage(anyListOf(CsvValidationFailure.class))).thenReturn("message");
-        when(validationService.validateHeaders(anyMapOf(String.class, Integer.class))).thenReturn(emptyList());
+        when(validationService.validateHeaders(anyListOf(String.class))).thenReturn(emptyList());
         when(validationService.validateRecords(any(Iterator.class), any(PermissionScope.class)))
                 .thenAnswer(invocation -> {
                     final Iterator<CSVRecord> recordIterator = (Iterator<CSVRecord>) invocation.getArgumentAt(0, Iterator.class);
@@ -113,7 +112,7 @@ public class DefaultStudentGroupBatchServiceTest {
     public void itShouldNotUploadIfColumnHeadersAreMissing() throws IOException {
         final String payload = payload(ValidHeaders, ValidValues);
         when(file.getInputStream()).thenReturn(new ByteArrayInputStream(payload.getBytes()));
-        when(validationService.validateHeaders(anyMapOf(String.class, Integer.class)))
+        when(validationService.validateHeaders(anyListOf(String.class)))
                 .thenReturn(Collections.singletonList(CsvValidationFailure.builder()
                         .row(0)
                         .message("Bad stuffs")


### PR DESCRIPTION
With the CSV-to-DB load script in place, the CSV header order is now required to be known.  This adds CSV header order validation during the CSV upload process.