### PR TITLE
Change service interface to accept a list of headers rather than a map

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
@@ -2,6 +2,7 @@ package org.opentestsystem.rdw.admin.service.impl;
 
 import com.amazonaws.services.s3.Headers;
 import com.google.common.base.Charsets;
+import com.google.common.collect.Ordering;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.csv.CSVFormat;
@@ -37,8 +38,9 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 @Service
 @EnableBinding(Source.class)
@@ -173,10 +175,9 @@ class DefaultStudentGroupBatchService implements StudentGroupBatchService {
                 return validationFailures;
             }
 
-            final List<String> orderedHeaders = new ArrayList<>(parser.getHeaderMap().size());
-            for (final Map.Entry<String, Integer> entry : parser.getHeaderMap().entrySet()) {
-                orderedHeaders.add(entry.getValue(), entry.getKey());
-            }
+            final List<String> orderedHeaders = newArrayList(parser.getHeaderMap().keySet());
+            final Ordering<String> ordering = Ordering.natural().onResultOf(header -> parser.getHeaderMap().get(header));
+            orderedHeaders.sort(ordering);
             validationFailures.addAll(validationService.validateHeaders(orderedHeaders));
             validationFailures.addAll(validationService.validateRecords(recordIterator, permissionScope));
 


### PR DESCRIPTION
This PR fixes an out of bounds exception being thrown during CSV validation