### PR TITLE
modifying how we tag the docker file based on release or not

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ subprojects {
         task buildImage(type: DockerBuildImage, dependsOn: [build, createDockerfile]) {
             dockerFile = createDockerfile.destFile
             inputDir = project.file('build/docker/')
-            tag = "${dockerPrefix}/${project.name}"
+            tag = "${dockerPrefix}/${project.name}" + (project.hasProperty("release") ? ":${project.version}" : "")
             doFirst {
                 copy {
                     from jar


### PR DESCRIPTION
The change is that, if doing a ./gradlew dockerPushImage -Pbuildnumber=RELEASE -Prelease, the -Prelease will force the docker image tag to be a versioned tag, which will not overwrite LATEST in dockerHub, but will create a version of the image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/smarterapp/rdw_admin/38)
<!-- Reviewable:end -->
