### PR TITLE
DWR-831 Check for extra headers past required headers to prevent erro…

### DIFF
--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationService.java
@@ -71,6 +71,14 @@ public class DefaultCsvValidationService implements CsvValidationService {
                 break;
             }
         }
+        if ( csvHeaders.size() > RequiredHeaders.size() ) {
+            failures.add(CsvValidationFailure.builder()
+                    .row(0)
+                    .message("Invalid headers. Additional headers exist after required headers: [" +
+                            Joiner.on(",").join(RequiredHeaders) +
+                            "]")
+                    .build());
+        }
         return failures;
     }
 

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultCsvValidationServiceTest.java
@@ -74,6 +74,18 @@ public class DefaultCsvValidationServiceTest {
     }
 
     @Test
+    public void itShouldNotValidateAdditionalHeadersPastValidHeaders() {
+        final List<String> additionalHeaders = newArrayList(RequiredHeaders);
+        additionalHeaders.add("extra_header_at_end");
+
+        final CsvValidationFailure failure = service.validateHeaders(additionalHeaders).get(0);
+
+        assertThat(failure.getRow()).isEqualTo(0);
+        assertThat(failure.getMessage()).contains("Additional headers");
+        assertThat(failure.getMessage()).contains(Joiner.on(",").join(RequiredHeaders));
+    }
+
+    @Test
     public void itShouldNotValidateOutOfOrderHeaders() {
         final List<String> misOrderedHeaders = newLinkedList(RequiredHeaders);
         misOrderedHeaders.add(misOrderedHeaders.remove(0));


### PR DESCRIPTION
The original error reported by DWR-831 mentions an error writing to S3 and I expect this is a system error.  We should think about errors message in this category.

Turns out there is a problem if the valid headers exist but there is an extra column, or at least an extra header at the end.  When deployed on AWS group processor will fail loading from S3 with an extra header, this does not appear to be the case in local environment.