### PR TITLE
Setting a height instead of using padding alone allows drag and drop …

### DIFF
--- a/webapp/src/main/webapp/src/styles.less
+++ b/webapp/src/main/webapp/src/styles.less
@@ -139,6 +139,7 @@ footer {
 .my-drop-zone {
   border: dotted 3px lightgray;
   border-radius: 5px;
+  height: 118px; /* Required for drag & drop to work in IE11 */
 }
 
 .nv-file-over {


### PR DESCRIPTION
…to work in IE11.

This is the height of the box after padding is applied.