### PR TITLE
DWR-1026 Handle an optional BOM character in uploaded CSVs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects {
 
             // commonly used libraries
             dependency 'com.google.guava:guava:21.0'
-            dependency 'org.apache.commons:commons-io:1.3.2'
+            dependency 'commons-io:commons-io:2.5'
             dependency 'org.slf4j:slf4j-api:1.7.25'
             dependency 'org.thymeleaf:thymeleaf:3.0.6.RELEASE'
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile 'org.opentestsystem.rdw.common:rdw-common-security'
     compile 'org.opentestsystem.rdw.common:rdw-common-utils'
     compile 'javax.validation:validation-api'
-    compile 'org.apache.commons:commons-io'
+    compile 'commons-io:commons-io'
     compile 'com.google.guava:guava'
     compile 'com.fasterxml.jackson.core:jackson-annotations'
     compile 'com.fasterxml.jackson.core:jackson-databind'

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
     compile 'com.google.guava:guava'
     compile 'mysql:mysql-connector-java'
-    compile 'org.apache.commons:commons-io'
+    compile 'commons-io:commons-io'
     compile 'org.opentestsystem.rdw.common:rdw-common-archive'
     compile 'org.opentestsystem.rdw.common:rdw-common-messaging'
     compile 'org.opentestsystem.rdw.common:rdw-common-model'

--- a/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
+++ b/webapp/src/main/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchService.java
@@ -8,7 +8,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.opentestsystem.rdw.security.PermissionScope;
+import org.apache.commons.io.input.BOMInputStream;
 import org.opentestsystem.rdw.admin.model.CsvValidationResult;
 import org.opentestsystem.rdw.admin.model.GroupMessage;
 import org.opentestsystem.rdw.admin.model.ImportStatus;
@@ -20,6 +20,7 @@ import org.opentestsystem.rdw.admin.service.GroupsSource;
 import org.opentestsystem.rdw.admin.service.LocationStrategy;
 import org.opentestsystem.rdw.admin.service.StudentGroupBatchService;
 import org.opentestsystem.rdw.archive.ArchiveService;
+import org.opentestsystem.rdw.security.PermissionScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -168,7 +169,7 @@ class DefaultStudentGroupBatchService implements StudentGroupBatchService {
     private List<CsvValidationResult> validate(final InputStream inputStream, final PermissionScope permissionScope) throws IOException {
 
         final List<CsvValidationResult> failures = newArrayList();
-        try (final Reader reader = new InputStreamReader(inputStream, Charsets.UTF_8)) {
+        try (final Reader reader = new InputStreamReader(new BOMInputStream(inputStream), Charsets.UTF_8)) {
             final CSVParser parser = CSVFormat.DEFAULT
                     .withFirstRecordAsHeader()
                     .withIgnoreHeaderCase()

--- a/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchServiceTest.java
+++ b/webapp/src/test/java/org/opentestsystem/rdw/admin/service/impl/DefaultStudentGroupBatchServiceTest.java
@@ -9,6 +9,11 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.csv.CSVRecord;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.opentestsystem.rdw.admin.model.CsvValidationResult;
 import org.opentestsystem.rdw.admin.model.ImportStatus;
 import org.opentestsystem.rdw.admin.model.StudentGroupBatch;
@@ -29,13 +34,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class DefaultStudentGroupBatchServiceTest {
     private static final Joiner CommaJoiner = Joiner.on(",");
     private static final Joiner LineJoiner = Joiner.on("\n");
@@ -43,18 +51,30 @@ public class DefaultStudentGroupBatchServiceTest {
     private static final List<String> ValidHeaders = ImmutableList.of("header_a", "header_b");
 
     private static final List<String> ValidValues = ImmutableList.copyOf(ValidHeaders.stream()
-            .map(header -> header + "_val")
+            .map(header -> header + "_val_汉字")
             .collect(Collectors.toList()));
 
+    @Mock
     private StudentGroupBatchRepository repository;
+
+    @Mock
     private ArchiveService archiveService;
-    private DefaultStudentGroupBatchService service;
-    private MultipartFile file;
-    private CsvValidationService validationService;
+
+    @Mock
     private GroupsSource source;
 
-    private Permission groupWrite = new Permission("GROUP_WRITE", PermissionScope.STATEWIDE);
-    private User user = User.builder()
+    @Mock
+    private CsvValidationService validationService;
+
+    @Captor
+    private ArgumentCaptor<List<String>> headerCaptor;
+
+    private DefaultStudentGroupBatchService service;
+    private MultipartFile file;
+    private List<List<String>> values;
+
+    private final Permission groupWrite = new Permission("GROUP_WRITE", PermissionScope.STATEWIDE);
+    private final User user = User.builder()
             .id("user")
             .username("test")
             .password("password")
@@ -64,17 +84,16 @@ public class DefaultStudentGroupBatchServiceTest {
 
     @Before
     public void before() {
-        repository = mock(StudentGroupBatchRepository.class);
-        archiveService = mock(ArchiveService.class);
-        source = mock(GroupsSource.class);
-        validationService = mock(CsvValidationService.class);
         when(validationService.toFailureMessage(anyListOf(CsvValidationResult.class))).thenReturn("message");
         when(validationService.validateHeaders(anyListOf(String.class))).thenReturn(emptyList());
+
+        values = newArrayList();
         when(validationService.validateRecords(any(Iterator.class), any(PermissionScope.class)))
                 .thenAnswer(invocation -> {
                     final Iterator<CSVRecord> recordIterator = (Iterator<CSVRecord>) invocation.getArgumentAt(0, Iterator.class);
                     while (recordIterator.hasNext()) {
-                        recordIterator.next();
+                        final CSVRecord record = recordIterator.next();
+                        values.add(newArrayList(record.iterator()));
                     }
                     return Collections.emptyList();
                 });
@@ -97,7 +116,7 @@ public class DefaultStudentGroupBatchServiceTest {
     }
 
     @Test
-    public void itShouldUpload() throws IOException {
+    public void itShouldUploadAndValidate() throws IOException {
         final String payload = payload(ValidHeaders, ValidValues);
         when(file.getInputStream()).thenReturn(new ByteArrayInputStream(payload.getBytes()));
 
@@ -107,6 +126,8 @@ public class DefaultStudentGroupBatchServiceTest {
                 .digest(DigestUtils.md5Hex(payload.getBytes()).toUpperCase())
                 .build();
         assertThat(service.upload(user, file)).isEqualTo(batch);
+        assertThat(values).hasSize(1);
+        assertThat(values.get(0)).containsExactlyElementsOf(ValidValues);
     }
 
     @Test
@@ -131,7 +152,6 @@ public class DefaultStudentGroupBatchServiceTest {
     @Test
     public void itShouldNotUploadEmptyFile() throws IOException {
         when(file.getInputStream()).thenReturn(new ByteArrayInputStream("".getBytes()));
-
         final StudentGroupBatch batch = StudentGroupBatch.builder()
                 .creator(user.getUsername())
                 .status(ImportStatus.BAD_DATA)
@@ -152,6 +172,18 @@ public class DefaultStudentGroupBatchServiceTest {
                 .message("Exception processing upload: failed")
                 .build();
         assertThat(service.upload(user, file)).isEqualTo(batch);
+    }
+
+    @Test
+    public void itShouldHandleBOMBytes() throws Exception {
+        final String payloadWithBOM = '\uFEFF' + payload(ValidHeaders, ValidValues);
+        when(file.getInputStream()).thenReturn(new ByteArrayInputStream(payloadWithBOM.getBytes()));
+
+        service.upload(user, file);
+
+        verify(validationService).validateHeaders(headerCaptor.capture());
+        final List<String> headers = headerCaptor.getValue();
+        assertThat(headers).containsExactlyElementsOf(ValidHeaders);
     }
 
     private String payload(final List<String> headers, final List<String> values) {


### PR DESCRIPTION
When uploading a CSV from IE11, a BOM character is added to the uploaded CSV.  This leads to a CSV header column of "u'\ufeff'group_name" rather than "group_name" which causes validation failures.

This PR wraps the InputStream in an apache commons-io BOMInputStream that strips BOM bytes from the stream if they exist.